### PR TITLE
[test] Validate gemmology with -fsanitize=address

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,12 +9,15 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: '${{ matrix.sys.compiler }}'
+    name: '${{ matrix.sys.compiler }} / ${{ matrix.flags.cxxflags }}'
     strategy:
       matrix:
         sys:
           - { compiler: 'g++'}
           - { compiler: 'clang++'}
+        flags:
+          - { cxxflags: '-O2' }
+          - { cxxflags: '-O0 -g -fsanitize=address' }
     steps:
     - name: Setup GCC
       if: ${{ matrix.sys.compiler == 'g++' }}
@@ -40,8 +43,8 @@ jobs:
 
     - name: Check GCC
       if: ${{ matrix.sys.compiler == 'g++' }}
-      run: make -C test CXX=${{ matrix.sys.compiler }} SDE64=../sde-external-9.21.1-2023-04-24-lin/sde64 XSIMD_INCLUDE_DIR=../xsimd/include CXXFLAGS=-Wall\ -Wno-psabi\ -Werror -j ARM_CXX=arm-linux-gnueabihf-g++ ARM_QEMU=qemu-arm\ -L\ /usr/arm-linux-gnueabihf ARM64_CXX=aarch64-linux-gnu-g++ ARM64_QEMU=qemu-aarch64\ -L\ /usr/aarch64-linux-gnu
+      run: make -C test CXX=${{ matrix.sys.compiler }} "CXXFLAGS=-Wall -Wno-psabi -Wno-unused-result -Werror ${{ matrix.flags.cxxflags }}" SDE64=../sde-external-9.21.1-2023-04-24-lin/sde64 XSIMD_INCLUDE_DIR=../xsimd/include -j ARM_CXX=arm-linux-gnueabihf-g++ ARM_QEMU=qemu-arm\ -L\ /usr/arm-linux-gnueabihf ARM64_CXX=aarch64-linux-gnu-g++ ARM64_QEMU=qemu-aarch64\ -L\ /usr/aarch64-linux-gnu
 
     - name: Check Clang
       if: ${{ matrix.sys.compiler == 'clang++' }}
-      run: make -C test CXX=${{ matrix.sys.compiler }} SDE64=../sde-external-9.21.1-2023-04-24-lin/sde64 XSIMD_INCLUDE_DIR=../xsimd/include CXXFLAGS=-Wall\ -Wno-psabi\ -Werror -j NOOMP=1
+      run: make -C test CXX=${{ matrix.sys.compiler }} "CXXFLAGS=-Wall -Wno-psabi -Wno-unused-result -Werror ${{ matrix.flags.cxxflags }}" SDE64=../sde-external-9.21.1-2023-04-24-lin/sde64 XSIMD_INCLUDE_DIR=../xsimd/include -j NOOMP=1

--- a/gemmology.h
+++ b/gemmology.h
@@ -1139,7 +1139,9 @@ void Engine<Arch>::Quantize(const float *const input, int8_t *const output,
   }
   auto result =
       QuantizeTile8::Tile(q, inputs[0], inputs[1], inputs[2], inputs[3]);
-  std::memcpy(output + (size & ~(kBatch - 1)), &result, overhang);
+  alignas(Arch::alignment()) int8_t buffer[kBatch];
+  result.store_aligned(buffer);
+  std::memcpy(output + (size & ~(kBatch - 1)), buffer, overhang);
 }
 
 template <class Arch>

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,22 +23,23 @@ check:check.avx2 check.avxvnni check.sse4 check.ssse3 check.sse2 check.avx512 ch
 
 clean:clean.avx2 clean.avxvnni clean.sse4 clean.ssse3 clean.sse2 clean.avx512 clean.avx512vnni clean.neon clean.neon64 clean.neon64+i8mm clean.thread $(if $(NOOMP),,clean.omp)
 
+GEMMOLOGY_NOASAN_CXXFLAGS=$(filter-out -fsanitize=address,$(GEMMOLOGY_CXXFLAGS))
 
 # AVX512VNNI
 test_transpose.avx512vnni: test_transpose.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_prepare_b_transposed.avx512vnni: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_prepare_b_quantized_transposed.avx512vnni: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_multiply.avx512vnni:test_multiply.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_quantize.avx512vnni:test_quantize.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@  -mavx512vnni -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 check.avx512vnni:test_prepare_b_transposed.avx512vnni test_prepare_b_quantized_transposed.avx512vnni test_multiply.avx512vnni test_quantize.avx512vnni test_transpose.avx512vnni
 	$(SDE64) -icx -- ./test_transpose.avx512vnni
@@ -53,19 +54,19 @@ clean.avx512vnni:
 
 # AVX512
 test_transpose.avx512: test_transpose.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_prepare_b_transposed.avx512: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_prepare_b_quantized_transposed.avx512: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_multiply.avx512:test_multiply.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 test_quantize.avx512:test_quantize.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavx512bw -mavx512f -mavx512dq -mavx512cd
 
 check.avx512:test_prepare_b_transposed.avx512 test_prepare_b_quantized_transposed.avx512 test_multiply.avx512 test_quantize.avx512 test_transpose.avx512
 	$(SDE64) -skx -- ./test_transpose.avx512
@@ -79,19 +80,19 @@ clean.avx512:
 
 # AVXVNNI
 test_transpose.avxvnni: test_transpose.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavxvnni
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavxvnni
 
 test_prepare_b_transposed.avxvnni: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavxvnni
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavxvnni
 
 test_prepare_b_quantized_transposed.avxvnni: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavxvnni
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavxvnni
 
 test_multiply.avxvnni:test_multiply.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavxvnni
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavxvnni
 
 test_quantize.avxvnni:test_quantize.cpp Makefile ../gemmology.h
-	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mavxvnni
+	$(CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mavxvnni
 
 check.avxvnni:test_prepare_b_transposed.avxvnni test_prepare_b_quantized_transposed.avxvnni test_multiply.avxvnni test_quantize.avxvnni test_transpose.avxvnni
 	$(SDE64) -adl -- ./test_transpose.avxvnni
@@ -210,16 +211,16 @@ clean.sse2:
 
 # Neon
 test_prepare_b_transposed.neon: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mfpu=neon
+	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mfpu=neon
 
 test_prepare_b_quantized_transposed.neon: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mfpu=neon
+	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mfpu=neon
 
 test_multiply.neon:test_multiply.cpp Makefile ../gemmology.h
-	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mfpu=neon
+	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mfpu=neon
 
 test_quantize.neon:test_quantize.cpp Makefile ../gemmology.h
-	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -mfpu=neon
+	$(ARM_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -mfpu=neon
 
 check.neon:test_prepare_b_transposed.neon test_prepare_b_quantized_transposed.neon test_multiply.neon test_quantize.neon
 	$(ARM_QEMU) ./test_prepare_b_transposed.neon
@@ -232,16 +233,16 @@ clean.neon:
 
 # Neon64
 test_prepare_b_transposed.neon64: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@
 
 test_prepare_b_quantized_transposed.neon64: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@
 
 test_multiply.neon64:test_multiply.cpp Makefile ../gemmology.h
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@
 
 test_quantize.neon64:test_quantize.cpp Makefile ../gemmology.h
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@
 
 check.neon64:test_prepare_b_transposed.neon64 test_prepare_b_quantized_transposed.neon64 test_multiply.neon64 test_quantize.neon64
 	$(ARM64_QEMU) ./test_prepare_b_transposed.neon64
@@ -254,16 +255,16 @@ clean.neon64:
 
 # Neon64+i8mm
 test_prepare_b_transposed.neon64+i8mm: test_prepare_b_transposed.cpp ../gemmology.h Makefile
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
 
 test_prepare_b_quantized_transposed.neon64+i8mm: test_prepare_b_quantized_transposed.cpp ../gemmology.h Makefile
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
 
 test_multiply.neon64+i8mm:test_multiply.cpp Makefile ../gemmology.h
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
 
 test_quantize.neon64+i8mm:test_quantize.cpp Makefile ../gemmology.h
-	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
+	$(ARM64_CXX) $(GEMMOLOGY_CPPFLAGS) $(GEMMOLOGY_NOASAN_CXXFLAGS) $< -o $@ -march=armv8.4-a+i8mm
 
 check.neon64+i8mm:test_prepare_b_transposed.neon64+i8mm test_prepare_b_quantized_transposed.neon64+i8mm test_multiply.neon64+i8mm test_quantize.neon64+i8mm
 	$(ARM64_QEMU) ./test_prepare_b_transposed.neon64+i8mm

--- a/test/test_multiply.cpp
+++ b/test/test_multiply.cpp
@@ -145,6 +145,10 @@ bool TestPrepare(int rows, int cols) {
     std::cerr << " Mismatch:\n";
     return false;
   }
+  free(input);
+  free(test);
+  free(quantized);
+  free(reference);
   return true;
 }
 #endif
@@ -170,7 +174,11 @@ bool TestPrepareA(int rows, int cols) {
   float quant_mult = 64; // From example
   gemmology::PrepareA(inputA, oldA, quant_mult, rows, cols);
   gemmology::Shift::PrepareA(inputA, newA, quant_mult, rows, cols);
-  return CompareAs(oldA, newA, rows, cols);
+  bool res =  CompareAs(oldA, newA, rows, cols);
+  free(inputA);
+  free(oldA);
+  free(newA);
+  return res;
 }
 
 bool TestSelectColumnsB(int rows, int cols) {
@@ -218,6 +226,12 @@ bool TestSelectColumnsB(int rows, int cols) {
     std::cerr << "mismatch\n";
     return false;
   }
+
+  free(input);
+  free(prepared);
+  free(test);
+  free(selected);
+  free(ref);
   return true;
 }
 
@@ -327,8 +341,20 @@ bool TestMultiplyShiftInt(int A_rows, int width, int B_cols,
                 return sum * unquant_mult + ShiftedBias[j];
               });
 
-  return CompareMSE(float_C, slowint_C, test_C, C_size, int_tolerance,
+  bool res = CompareMSE(float_C, slowint_C, test_C, C_size, int_tolerance,
                     float_tolerance, MSE_float_tolerance, MSE_int_tolerance);
+  free(A);
+  free(B);
+  free(bias);
+  free(A_prep);
+  free(B_prep);
+  free(test_C);
+  free(B_quant);
+  free(slowint_C);
+  free(float_C);
+  free(A_prep2);
+  free(ShiftedBias);
+  return res;
 }
 
 bool TestPrepareBias(int rows, int cols) {
@@ -391,7 +417,15 @@ bool TestPrepareBias(int rows, int cols) {
               [&](int32_t sum, int i, int j) {
                 return sum * unquant_mult_forprep + goldBias[j];
               });
-  return CompareEps(slowint_C, inputBias, cols, 0.0001f);
+  bool res =  CompareEps(slowint_C, inputBias, cols, 0.0001f);
+  free(inputB);
+  free(B_prep);
+  free(B_quant);
+  free(inputBias);
+  free(goldBias);
+  free(A_prep2);
+  free(slowint_C);
+  return res;
 }
 } // namespace
 

--- a/test/test_transpose.cpp
+++ b/test/test_transpose.cpp
@@ -43,6 +43,9 @@ bool TestTranspose16() {
       return false;
     }
   }
+
+  free(input);
+  free(ref);
   return true;
 }
 


### PR DESCRIPTION
Mostly test code cleaning, and a small workaround to prevent an invalid read warning when loading the end of a matrix: basically padding the allocated input to please ASAN. The exact behavior of loading a partially valid address range with simd instruction is not well defined, we currently assume it's ok.